### PR TITLE
ビルド時のgh-pages用のパス指定を追加

### DIFF
--- a/.github/workflows/deploy_for_ghpages.yml
+++ b/.github/workflows/deploy_for_ghpages.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   deploy:
@@ -15,21 +15,20 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
-    - run: npm ci
-    - run: npm run build --if-present
-    
-    - name: Deploy for gh-pages
-      uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist
-    
+      - run: npm ci
+      - run: npm run build:prod --if-present
+
+      - name: Deploy for gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite",
     "prebuild": "rimraf ./node_modules/@types/react",
     "build": "vue-tsc --noEmit && vite build",
+    "build:prod": "vue-tsc --noEmit && vite build --base=/povo-topping-manager/",
     "serve": "vite preview",
     "lint:script": "eslint --ext .ts,vue --ignore-path .gitignore .",
     "lint:style": "stylelint src/**/*.{css,scss,vue}",


### PR DESCRIPTION
## 概要
- `https://prismistim.github.io/povo-topping-manager/` で公開するため、 baseが / のみだとファイルが読み込めなかった
- `npm run build:prod` の時だけbaseを変更するよう修正

## 関連issue
#18 