### PR TITLE
fix: Cypress用の環境変数をDockerfileに追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk update && \
 RUN mkdir /app/node_modules && \
   chown -R node:node /app/node_modules
 
+ENV CYPRESS_CACHE_FOLDER=/home/node/.cache/Cypress
+
 COPY --chown=node:node package*.json /app/
 
 RUN cd /app && \


### PR DESCRIPTION
## 概要
- CYPRESS_CACHE_FOLDER を node のホームディレクトリに設定しエラー回避

Close #44 